### PR TITLE
Add rosdep Python 3 keys for tqdm

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5817,6 +5817,19 @@ python3-tornado:
       packages: [tornado]
   rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
+python3-tqdm:
+  alpine: [py3-tqdm]
+  debian:
+    stretch: [python3-tqdm]
+  fedora: [python3-tqdm]
+  osx:
+    pip:
+      packages: [tqdm]
+  ubuntu:
+    bionic: [python3-tqdm]
+    eoan: [python3-tqdm]
+    focal: [python3-tqdm]
+    groovy: [python3-tqdm]
 python3-triangle-pip:
   debian:
     pip:


### PR DESCRIPTION
Alpine: https://pkgs.alpinelinux.org/packages?name=py3-tqdm
Debian: https://packages.debian.org/stretch/python3-tqdm
Fedora: https://fedora.pkgs.org/30/fedora-x86_64/python3-tqdm-4.28.1-3.fc30.noarch.rpm.html
Ubuntu: https://packages.ubuntu.com/search?keywords=python3-tqdm

PyPi: https://pypi.org/project/tqdm